### PR TITLE
feat(config): Add ability to specify html file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ exports.config = {
     // Output json and html will go in this folder.
     outdir: 'timelines',
 
+    // Set the name of the html file. Defaults to index.html.
+    htmlFile: 'results.html'
+
     // Optional - if sauceUser and sauceKey are specified, logs from
     // SauceLabs will also be parsed after test invocation.
     sauceUser: 'Jane',

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ exports.config = {
     outdir: 'timelines',
 
     // Set the name of the html file. Defaults to index.html.
-    htmlFile: 'results.html'
+    outputHtmlFileName: 'results.html'
 
     // Optional - if sauceUser and sauceKey are specified, logs from
     // SauceLabs will also be parsed after test invocation.

--- a/index.js
+++ b/index.js
@@ -198,7 +198,7 @@ TimelinePlugin.prototype.outputResults = function(done) {
       path.join(__dirname, 'indextemplate.html'));
   var outfile = path.join(this.outdir, 'timeline.json');
   fs.writeFileSync(outfile, JSON.stringify(this.timeline));
-  stream.pipe(fs.createWriteStream(path.join(this.outdir, 'index.html')));
+  stream.pipe(fs.createWriteStream(path.join(this.outdir, this.config.htmlFile || 'index.html')));
   stream.on('end', done);
 };
 

--- a/index.js
+++ b/index.js
@@ -198,7 +198,7 @@ TimelinePlugin.prototype.outputResults = function(done) {
       path.join(__dirname, 'indextemplate.html'));
   var outfile = path.join(this.outdir, 'timeline.json');
   fs.writeFileSync(outfile, JSON.stringify(this.timeline));
-  stream.pipe(fs.createWriteStream(path.join(this.outdir, this.config.htmlFile || 'index.html')));
+  stream.pipe(fs.createWriteStream(path.join(this.outdir, this.config.outputHtmlFileName || 'index.html')));
   stream.on('end', done);
 };
 


### PR DESCRIPTION
Now, the user can optionally specify the name of the html file.
Defaults to `’index.html’`.
