### PR TITLE
fix(path): prefer `path.resolve`

### DIFF
--- a/index.js
+++ b/index.js
@@ -195,10 +195,10 @@ TimelinePlugin.prototype.outputResults = function(done) {
     if (e.code != 'EEXIST') throw e;
   }
   var stream = fs.createReadStream(
-      path.join(__dirname, 'indextemplate.html'));
-  var outfile = path.join(this.outdir, 'timeline.json');
+      path.resolve(__dirname, 'indextemplate.html'));
+  var outfile = path.resolve(this.outdir, 'timeline.json');
   fs.writeFileSync(outfile, JSON.stringify(this.timeline));
-  stream.pipe(fs.createWriteStream(path.join(this.outdir, this.config.outputHtmlFileName || 'index.html')));
+  stream.pipe(fs.createWriteStream(path.resolve(this.outdir, this.config.outputHtmlFileName || 'index.html')));
   stream.on('end', done);
 };
 

--- a/spec/unit.js
+++ b/spec/unit.js
@@ -5,7 +5,7 @@ var TimelinePlugin = require('../index.js').TimelinePlugin;
 describe('timeline plugin', function() {
   it('should parse an example selenium standalone log', function() {
     var timeline = TimelinePlugin.parseTextLog(
-        fs.readFileSync(path.join(__dirname, 'standalonelog.txt')).toString());
+        fs.readFileSync(path.resolve(__dirname, 'standalonelog.txt')).toString());
 
     expect(timeline.length).toEqual(23);
     expect(timeline[0].command).toEqual('new session');
@@ -14,7 +14,7 @@ describe('timeline plugin', function() {
 
   it('should parse an example chromedriver log', function() {
     var timeline = TimelinePlugin.parseTextLog(
-        fs.readFileSync(path.join(__dirname, 'chromelog.txt')).toString());
+        fs.readFileSync(path.resolve(__dirname, 'chromelog.txt')).toString());
 
     expect(timeline.length).toEqual(24);
     expect(timeline[0].command).toEqual('InitSession');


### PR DESCRIPTION
`path.join` does not account for absolute paths like `path.resolve` does.